### PR TITLE
Downgrade Sidekiq and lock version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,9 @@ gem 'state_machines-activerecord'
 
 # Background Jobs
 gem 'sinatra', require: false
-gem 'sidekiq'
+# Sidekiq is version locked because the production server has an ancient version
+# of Redis.
+gem 'sidekiq', '< 6'
 
 # Perf Check
 gem 'perf_check', github: 'rubytune/perf_check', branch: 'mst/47-spec-stability'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,11 +180,11 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    sidekiq (6.0.1)
-      connection_pool (>= 2.2.2)
-      rack (>= 2.0.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -247,7 +247,7 @@ DEPENDENCIES
   rails (~> 6.0)
   redis
   sass-rails
-  sidekiq
+  sidekiq (< 6)
   sinatra
   stamp
   state_machines-activerecord


### PR DESCRIPTION
The production server runs Redis 3.0 and Sidekiq 6 needs a newer version.