### PR TITLE
Store job output to the database immediately

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -36,7 +36,7 @@ class Job < ApplicationRecord
   end
 
   def run_perf_check!
-    job_output = JobOutput.new(id)
+    job_output = JobOutput.new(self)
     job_logger = Logger.new(job_output)
     begin
       perf_check = PerfCheck.new(app_dir)
@@ -48,8 +48,6 @@ class Job < ApplicationRecord
       true
     rescue
       false
-    ensure
-      update_column(:output, job_output.to_s)
     end
   end
 

--- a/app/models/job_output.rb
+++ b/app/models/job_output.rb
@@ -7,8 +7,8 @@ class JobOutput
   include ActionView::Helpers::TagHelper
   include JobHelper
 
-  def initialize(job_id)
-    @job_id = job_id
+  def initialize(job)
+    @job = job
     @data = +''
   end
 
@@ -18,13 +18,14 @@ class JobOutput
 
   def attributes
     {
-      id: @job_id,
+      id: @job.id,
       contents: render_log(@data)
     }
   end
 
   def write(message)
     @data << message
+    @job.update_column(:output, @data)
     ActionCable.server.broadcast('logs_channel', attributes)
   end
 


### PR DESCRIPTION
That way the job output is never blank for a started job in the interface.

Closes #38.