### PR TITLE
Concatenate job exceptions to the job output for now

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -46,7 +46,12 @@ class Job < ApplicationRecord
       perf_check.parse_arguments(all_arguments)
       parse_and_save_test_results!(perf_check.run)
       true
-    rescue
+    rescue StandardError => e
+      job_output.puts("JOB FAILED")
+      job_output.puts(e.message)
+      e.backtrace.each do |line|
+        job_output.puts(line)
+      end
       false
     end
   end

--- a/app/models/job_output.rb
+++ b/app/models/job_output.rb
@@ -23,6 +23,10 @@ class JobOutput
     }
   end
 
+  def puts(message)
+    write(message + "\n")
+  end
+
   def write(message)
     @data << message
     @job.update_column(:output, @data)

--- a/test/fixtures/jobs.yml
+++ b/test/fixtures/jobs.yml
@@ -7,8 +7,8 @@ lyra_queued_lra_optimizations:
   updated_at: <%= 12.seconds.ago %>
 lyra_queued_master_broken:
   user: lyra
-  branch: lra/optimizations
-  arguments: -n 1 --branch unknown
+  branch: broken
+  arguments: -n 1 --branch broken /
   status: queued
   created_at: <%= 15.seconds.ago %>
   updated_at: <%= 12.seconds.ago %>

--- a/test/models/job_output_test.rb
+++ b/test/models/job_output_test.rb
@@ -34,6 +34,11 @@ class JobOutputTest < ActiveSupport::TestCase
     assert_equal lines.join, @job.reload.output
   end
 
+  test 'responds to puts for convenience' do
+    @job_output.puts('Hi')
+    assert_equal "Hi\n", @job.reload.output
+  end
+
   test 'returns attributes to send to Action Cable channel' do
     assert_equal(
       { id: @job.id, contents: '' },


### PR DESCRIPTION
We want to know when something surrounding the job failed.

Closes #53.