### PR TITLE
Remove result details from jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,6 @@ gem 'sidekiq', '< 6'
 # Perf Check
 gem 'perf_check', github: 'rubytune/perf_check'
 
-# Markdown
-gem 'kramdown'
-
 # GitHub APIs
 gem 'octokit'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    kramdown (2.1.0)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -224,7 +223,6 @@ DEPENDENCIES
   faker
   font_awesome5_rails
   jquery-rails
-  kramdown
   octokit
   pagy
   perf_check!

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,9 +1,0 @@
-module MarkdownHelper
-  def markdown(text)
-    text.gsub!(/:white_check_mark:/,'<i class="fa fa-check-square" aria-hidden="true"></i>')
-    text.gsub!(/:warning:/,'<i class="fa fa-exclamation-triangle" aria-hidden="true"></i>')
-    text.gsub!(/:x:/,'<i class="fa fa-times-circle" aria-hidden="true"></i>')
-    text.gsub!(/:mag:/,'<i class="fa fa-search" aria-hidden="true"></i>')
-    Kramdown::Document.new(text, input: 'GFM', hard_wrap: true).to_html
-  end
-end

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -34,11 +34,6 @@
        <% end %>
       <% end %>
   </header>
-  <% if @job.result_details.present?  %>
-    <div class="details">
-      <%== markdown(@job.result_details) %>
-    </div>
-  <% end %>
   <% if @job.measurements.present? && @job.statistics.present? %>
     <%= render @job.report_sections %>
     <hr>

--- a/db/migrate/20191203094849_remove_result_details_from_jobs.rb
+++ b/db/migrate/20191203094849_remove_result_details_from_jobs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveResultDetailsFromJobs < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :jobs, :result_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_27_153137) do
+ActiveRecord::Schema.define(version: 2019_12_03_094849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define(version: 2019_11_27_153137) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "experiment_branch"
-    t.text "result_details"
     t.integer "user_id"
     t.string "github_html_url"
     t.text "output"


### PR DESCRIPTION
Removes `jobs.result_details` because the column was not populated after a job run.